### PR TITLE
fix: send only one response to the client

### DIFF
--- a/server/api/cart.js
+++ b/server/api/cart.js
@@ -6,7 +6,7 @@ router.post('/', (req, res, next) => {
   const productToAdd = req.body;
   req.session.cart[productToAdd.id] = productToAdd;
   res
-    .send(201)
+    .status(201)
     .json(req.session.cart)
     .catch(next);
 });


### PR DESCRIPTION
Fixed error where we were trying to send 2 responses to the client. 